### PR TITLE
chore: add a cI system to build images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,7 +133,7 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: kong/blixt-control-plane-test:latest
+        tags: kong/blixt-control-plane-test:test
     - name: Docker build - Data Plane
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
       with:
@@ -141,4 +141,4 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: kong/blixt-dataplane-test:latest
+        tags: kong/blixt-dataplane-test:test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
     - main
-permissions: write-all
 
 jobs:
   get-changed-files:
@@ -107,8 +106,6 @@ jobs:
   main-docker-build:
     name: Main branch Docker build
     needs: [ get-changed-files ]
-    permissions:
-      packages: write
     if: >-
       github.event_name == 'push' 
       && (

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
     - main
+    - chore/add-ci-system
 permissions: write-all
 
 jobs:
@@ -134,7 +135,7 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: kong/blixt-control-plane-test:test
+        tags: ghcr.io/kong/blixt-control-plane-test:test
     - name: Docker build - Data Plane
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
       with:
@@ -142,4 +143,4 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: kong/blixt-dataplane-test:test
+        tags: ghcr.io/kong/blixt-dataplane-test:test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
     - main
-    - chore/add-ci-system
-permissions: write-all
 
 jobs:
   get-changed-files:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,7 +129,7 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: ghcr.io/kong/blixt-control-plane:latest
+        tags: ghcr.io/kong/blixt-control-plane-test:latest
     - name: Docker build - Data Plane
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
       with:
@@ -137,4 +137,4 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: ghcr.io/kong/blixt-dataplane:latest
+        tags: ghcr.io/kong/blixt-dataplane-test:latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,10 +63,12 @@ jobs:
     name: PR Docker build
     needs: [ get-changed-files ]
     if: >-
-      github.event_name == 'pull_request' &&
-      (needs.get-changed-files.outputs.control-plane-changed == 'true' ||
-      needs.get-changed-files.outputs.dataplane-changed == 'true' ||
-      needs.get-changed-files.outputs.workflow-changed == 'true')
+      github.event_name == 'pull_request' 
+      && (
+        needs.get-changed-files.outputs.control-plane-changed == 'true'
+        || needs.get-changed-files.outputs.dataplane-changed == 'true'
+        || needs.get-changed-files.outputs.workflow-changed == 'true'
+      )
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -105,10 +107,12 @@ jobs:
     name: Main branch Docker build
     needs: [ get-changed-files ]
     if: >-
-      github.event_name == 'push' &&
-      (needs.get-changed-files.outputs.control-plane-changed == 'true' ||
-      needs.get-changed-files.outputs.dataplane-changed == 'true' ||
-      needs.get-changed-files.outputs.workflow-changed == 'true')
+      github.event_name == 'push' 
+      && (
+        needs.get-changed-files.outputs.control-plane-changed == 'true'
+        || needs.get-changed-files.outputs.dataplane-changed == 'true'
+        || needs.get-changed-files.outputs.workflow-changed == 'true'
+      )
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@c74574e6c82eeedc46366be1b0d287eff9085eb6
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,7 +133,7 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: ghcr.io/kong/blixt-control-plane-test:test
+        tags: ghcr.io/kong/blixt-control-plane:latest
     - name: Docker build - Data Plane
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
       with:
@@ -141,4 +141,4 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: ghcr.io/kong/blixt-dataplane-test:test
+        tags: ghcr.io/kong/blixt-dataplane:latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,6 +106,8 @@ jobs:
   main-docker-build:
     name: Main branch Docker build
     needs: [ get-changed-files ]
+    permissions:
+      packages: write
     if: >-
       github.event_name == 'push' 
       && (

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,9 +64,9 @@ jobs:
     needs: [ get-changed-files ]
     if: >-
       github.event_name == 'pull_request' &&
-      needs.get-changed-files.outputs.control-plane-changed == 'true' ||
+      (needs.get-changed-files.outputs.control-plane-changed == 'true' ||
       needs.get-changed-files.outputs.dataplane-changed == 'true' ||
-      needs.get-changed-files.outputs.workflow-changed == 'true'
+      needs.get-changed-files.outputs.workflow-changed == 'true')
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -106,9 +106,9 @@ jobs:
     needs: [ get-changed-files ]
     if: >-
       github.event_name == 'push' &&
-      needs.get-changed-files.outputs.control-plane-changed == 'true' ||
+      (needs.get-changed-files.outputs.control-plane-changed == 'true' ||
       needs.get-changed-files.outputs.dataplane-changed == 'true' ||
-      needs.get-changed-files.outputs.workflow-changed == 'true'
+      needs.get-changed-files.outputs.workflow-changed == 'true')
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
           go.sum
           main.go
           controllers/
+          LICENSE
     - name: Check if any files related to the building of the dataplane image have changed (see the Dockerfiles)
       uses: tj-actions/changed-files@1d6e210c970d01a876fbc6155212d068e79ca584
       id: dataplane-changed
@@ -45,6 +46,7 @@ jobs:
           dataplane/main.go
           dataplane/xdp.c
           dataplane/Makefile
+          dataplane/LICENCE
     - name: Check if any of the workflow files have changed
       uses: tj-actions/changed-files@1d6e210c970d01a876fbc6155212d068e79ca584
       id: workflow-changed
@@ -78,23 +80,63 @@ jobs:
         context: .
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: kong/blixt-control-plane:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+        tags: ghcr.io/kong/blixt-control-plane:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
         outputs: type=docker,dest=/tmp/blixt-control-plane.tar
-    - name: Upload Image Artifact
+    - name: Upload Image Artifact - Control Plane
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
       with:
         name: blixt-control-plane
         path: /tmp/blixt-control-plane.tar
-    - name: Docker build - Data Plane
+    - name: Docker build - Dataplane
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
       with:
         context: dataplane
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: kong/blixt-dataplane:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+        tags: ghcr.io/kong/blixt-dataplane:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
         outputs: type=docker,dest=/tmp/blixt-dataplane.tar
-    - name: Upload Image Artifact
+    - name: Upload Image Artifact - Dataplane
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
       with:
         name: blixt-dataplane
         path: /tmp/blixt-dataplane.tar
+
+  main-docker-build:
+    name: Main branch Docker build
+    needs: [ get-changed-files ]
+    if: >-
+      github.event_name == 'push' &&
+      needs.get-changed-files.outputs.control-plane-changed == 'true' ||
+      needs.get-changed-files.outputs.dataplane-changed == 'true' ||
+      needs.get-changed-files.outputs.workflow-changed == 'true'
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@c74574e6c82eeedc46366be1b0d287eff9085eb6
+      with:
+        install: true
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Docker build - Control Plane
+      uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
+      with:
+        context: .
+        push: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        tags: ghcr.io/kong/blixt-control-plane:latest
+        outputs: type=docker,dest=/tmp/blixt-control-plane.tar
+    - name: Docker build - Data Plane
+      uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
+      with:
+        context: dataplane
+        push: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        tags: ghcr.io/kong/blixt-dataplane:latest
+        outputs: type=docker,dest=/tmp/blixt-dataplane.tar

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: CI
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 on:
   pull_request: {}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,13 +33,13 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@e2f20e6
+    - uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@c74574e
+      uses: docker/setup-buildx-action@c74574e6c82eeedc46366be1b0d287eff9085eb6
       with:
         install: true
     - name: Docker build
-      uses: docker/build-push-action@c56af95
+      uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
       with:
         context: .
         cache-from: type=gha
@@ -47,7 +47,7 @@ jobs:
         tags: kong/blixt-control-plane:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
         outputs: type=docker,dest=/tmp/blixt-control-plane.tar
     - name: Upload Image Artifact
-      uses: actions/upload-artifact@3cea537
+      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
       with:
         name: blixt-control-plane
         path: /tmp/blixt-control-plane.tar

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,53 @@
+name: CI
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+on:
+  pull_request: {}
+  push:
+    branches:
+    - main
+
+jobs:
+#  get-changed-files:
+#    name: Get Changed Files
+#    runs-on: ubuntu-20.04
+#    outputs:
+#      changed-files: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
+#    steps:
+#    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+#      with:
+#        fetch-depth: 0
+#    - name: Get list of all changes
+#      uses: tj-actions/changed-files@v32.1.0
+#      id: changed-files
+#    - name: List all changed files
+#      run: |
+#        for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+#          echo "$file"
+#        done
+
+  pr-docker-build:
+    name: PR Docker build - Control Plane
+#    needs: [ get-changed-files ]
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@e2f20e6
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@c74574e
+      with:
+        install: true
+    - name: Docker build
+      uses: docker/build-push-action@c56af95
+      with:
+        context: .
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        tags: kong/blixt-control-plane:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+        outputs: type=docker,dest=/tmp/blixt-control-plane.tar
+    - name: Upload Image Artifact
+      uses: actions/upload-artifact@3cea537
+      with:
+        name: blixt-control-plane
+        path: /tmp/blixt-control-plane.tar

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
     - main
+permissions: write-all
 
 jobs:
   get-changed-files:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,7 +82,7 @@ jobs:
         context: .
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: ghcr.io/kong/blixt-control-plane:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+        tags: kong/blixt-control-plane:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
         outputs: type=docker,dest=/tmp/blixt-control-plane.tar
     - name: Upload Image Artifact - Control Plane
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
@@ -95,7 +95,7 @@ jobs:
         context: dataplane
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: ghcr.io/kong/blixt-dataplane:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+        tags: kong/blixt-dataplane:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
         outputs: type=docker,dest=/tmp/blixt-dataplane.tar
     - name: Upload Image Artifact - Dataplane
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
@@ -133,7 +133,7 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: ghcr.io/kong/blixt-control-plane-test:latest
+        tags: kong/blixt-control-plane-test:latest
     - name: Docker build - Data Plane
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
       with:
@@ -141,4 +141,4 @@ jobs:
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        tags: ghcr.io/kong/blixt-dataplane-test:latest
+        tags: kong/blixt-dataplane-test:latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,7 +130,6 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         tags: ghcr.io/kong/blixt-control-plane:latest
-        outputs: type=docker,dest=/tmp/blixt-control-plane.tar
     - name: Docker build - Data Plane
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
       with:
@@ -139,4 +138,3 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         tags: ghcr.io/kong/blixt-dataplane:latest
-        outputs: type=docker,dest=/tmp/blixt-dataplane.tar

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,7 +88,7 @@ jobs:
     - name: Docker build - Data Plane
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
       with:
-        context: .
+        context: dataplane
         cache-from: type=gha
         cache-to: type=gha,mode=max
         tags: kong/blixt-dataplane:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,28 +9,62 @@ on:
     - main
 
 jobs:
-#  get-changed-files:
-#    name: Get Changed Files
-#    runs-on: ubuntu-20.04
-#    outputs:
-#      changed-files: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
-#    steps:
-#    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
-#      with:
-#        fetch-depth: 0
-#    - name: Get list of all changes
-#      uses: tj-actions/changed-files@v32.1.0
-#      id: changed-files
-#    - name: List all changed files
-#      run: |
-#        for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
-#          echo "$file"
-#        done
+  get-changed-files:
+    name: Get Changed Files
+    runs-on: ubuntu-20.04
+    outputs:
+      changed-files: ${{ steps.changed-files.outputs.all_changed_and_modified_files }}
+      control-plane-changed: ${{ steps.control-plane-changed.outputs.any_modified }}
+      dataplane-changed: ${{ steps.dataplane-changed.outputs.any_modified }}
+      workflow-changed: ${{ steps.workflow-changed.outputs.any_modified }}
+    steps:
+    - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      with:
+        fetch-depth: 0
+    - name: Get list of all changes
+      uses: tj-actions/changed-files@1d6e210c970d01a876fbc6155212d068e79ca584
+      id: changed-files
+    - name: Check if any files related to the building of the control plane image have changed (see the Dockerfiles)
+      uses: tj-actions/changed-files@1d6e210c970d01a876fbc6155212d068e79ca584
+      id: control-plane-changed
+      with:
+        files: |
+          Dockerfile
+          go.mod
+          go.sum
+          main.go
+          controllers/
+    - name: Check if any files related to the building of the dataplane image have changed (see the Dockerfiles)
+      uses: tj-actions/changed-files@1d6e210c970d01a876fbc6155212d068e79ca584
+      id: dataplane-changed
+      with:
+        files: |
+          dataplane/Dockerfile
+          dataplane/go.mod
+          dataplane/go.sum
+          dataplane/main.go
+          dataplane/xdp.c
+          dataplane/Makefile
+    - name: Check if any of the workflow files have changed
+      uses: tj-actions/changed-files@1d6e210c970d01a876fbc6155212d068e79ca584
+      id: workflow-changed
+      with:
+        files: |
+          .github/workflows/
+    - name: List all changed files
+      run: |
+        for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+          echo "$file"
+        done
 
   pr-docker-build:
-    name: PR Docker build - Control Plane
-#    needs: [ get-changed-files ]
-    if: github.event_name == 'pull_request'
+    name: PR Docker build
+    needs: [ get-changed-files ]
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.get-changed-files.outputs.control-plane-changed == 'true' ||
+      needs.get-changed-files.outputs.dataplane-changed == 'true' ||
+      needs.get-changed-files.outputs.workflow-changed == 'true'
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
@@ -38,7 +72,7 @@ jobs:
       uses: docker/setup-buildx-action@c74574e6c82eeedc46366be1b0d287eff9085eb6
       with:
         install: true
-    - name: Docker build
+    - name: Docker build - Control Plane
       uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
       with:
         context: .
@@ -51,3 +85,16 @@ jobs:
       with:
         name: blixt-control-plane
         path: /tmp/blixt-control-plane.tar
+    - name: Docker build - Data Plane
+      uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5
+      with:
+        context: .
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        tags: kong/blixt-dataplane:pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+        outputs: type=docker,dest=/tmp/blixt-dataplane.tar
+    - name: Upload Image Artifact
+      uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
+      with:
+        name: blixt-dataplane
+        path: /tmp/blixt-dataplane.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary
 FROM golang:1.19 as builder
 
-LABEL org.opencontainers.image.source=https://github.com/kong/blixt-workflow-test
+LABEL org.opencontainers.image.source=https://github.com/kong/blixt
 LABEL org.opencontainers.image.description="An experimental layer 4 load-balancer built using eBPF/XDP with ebpf-go \
 for use in Kubernetes via the Kubernetes Gateway API"
 LABEL org.opencontainers.image.licenses=Apache-2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY LICENSE /workspace/LICENSE
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary
 FROM golang:1.19 as builder
 
-LABEL org.opencontainers.image.source=https://github.com/kong/blixt
+LABEL org.opencontainers.image.source=https://github.com/kong/blixt-control-plane-test
 LABEL org.opencontainers.image.description="An experimental layer 4 load-balancer built using eBPF/XDP with ebpf-go \
 for use in Kubernetes via the Kubernetes Gateway API"
 LABEL org.opencontainers.image.licenses=Apache-2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary
 FROM golang:1.19 as builder
 
-LABEL org.opencontainers.image.source https://github.com/kong/blixt
+LABEL org.opencontainers.image.source=https://github.com/kong/blixt
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@
 FROM golang:1.19 as builder
 
 LABEL org.opencontainers.image.source=https://github.com/kong/blixt
+LABEL org.opencontainers.image.licenses=Apache-2.0
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.19 as builder
 
 LABEL org.opencontainers.image.source=https://github.com/kong/blixt
-LABEL org.opencontainers.image.description=\"An experimental layer 4 load-balancer built using eBPF/XDP with ebpf-go \
+LABEL org.opencontainers.image.description="An experimental layer 4 load-balancer built using eBPF/XDP with ebpf-go \
 for use in Kubernetes via the Kubernetes Gateway API"
 LABEL org.opencontainers.image.licenses=Apache-2.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 FROM golang:1.19 as builder
 
 LABEL org.opencontainers.image.source=https://github.com/kong/blixt
+LABEL org.opencontainers.image.description=\"An experimental layer 4 load-balancer built using eBPF/XDP with ebpf-go \
+for use in Kubernetes via the Kubernetes Gateway API"
 LABEL org.opencontainers.image.licenses=Apache-2.0
 
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary
 FROM golang:1.19 as builder
 
-LABEL org.opencontainers.image.source=https://github.com/kong/blixt-control-plane-test
+LABEL org.opencontainers.image.source=https://github.com/kong/blixt-workflow-test
 LABEL org.opencontainers.image.description="An experimental layer 4 load-balancer built using eBPF/XDP with ebpf-go \
 for use in Kubernetes via the Kubernetes Gateway API"
 LABEL org.opencontainers.image.licenses=Apache-2.0

--- a/dataplane/Dockerfile
+++ b/dataplane/Dockerfile
@@ -1,6 +1,6 @@
 FROM archlinux as builder
 
-LABEL org.opencontainers.image.source=https://github.com/kong/blixt
+LABEL org.opencontainers.image.source=https://github.com/kong/blixt-dataplane-test
 LABEL org.opencontainers.image.licenses=GPL-2.0-only
 
 RUN pacman -Syu --noconfirm

--- a/dataplane/Dockerfile
+++ b/dataplane/Dockerfile
@@ -1,6 +1,9 @@
 FROM archlinux as builder
 
 LABEL org.opencontainers.image.source=https://github.com/kong/blixt
+LABEL org.opencontainers.image.description=\"An experimental layer 4 load-balancer built using eBPF/XDP with ebpf-go \
+for use in Kubernetes via the Kubernetes Gateway API"
+LABEL org.opencontainers.image.licenses=GPL-2.0-only
 
 RUN pacman -Syu --noconfirm
 RUN pacman -S base-devel bpf git make go clang llvm linux-headers --noconfirm

--- a/dataplane/Dockerfile
+++ b/dataplane/Dockerfile
@@ -1,8 +1,6 @@
 FROM archlinux as builder
 
 LABEL org.opencontainers.image.source=https://github.com/kong/blixt
-LABEL org.opencontainers.image.description=\"An experimental layer 4 load-balancer built using eBPF/XDP with ebpf-go \
-for use in Kubernetes via the Kubernetes Gateway API"
 LABEL org.opencontainers.image.licenses=GPL-2.0-only
 
 RUN pacman -Syu --noconfirm

--- a/dataplane/Dockerfile
+++ b/dataplane/Dockerfile
@@ -1,6 +1,6 @@
 FROM archlinux as builder
 
-LABEL org.opencontainers.image.source https://github.com/kong/blixt
+LABEL org.opencontainers.image.source=https://github.com/kong/blixt
 
 RUN pacman -Syu --noconfirm
 RUN pacman -S base-devel bpf git make go clang llvm linux-headers --noconfirm

--- a/dataplane/Dockerfile
+++ b/dataplane/Dockerfile
@@ -1,6 +1,6 @@
 FROM archlinux as builder
 
-LABEL org.opencontainers.image.source=https://github.com/kong/blixt-workflow-test
+LABEL org.opencontainers.image.source=https://github.com/kong/blixt
 LABEL org.opencontainers.image.licenses=GPL-2.0-only
 
 RUN pacman -Syu --noconfirm

--- a/dataplane/Dockerfile
+++ b/dataplane/Dockerfile
@@ -1,6 +1,6 @@
 FROM archlinux as builder
 
-LABEL org.opencontainers.image.source=https://github.com/kong/blixt-dataplane-test
+LABEL org.opencontainers.image.source=https://github.com/kong/blixt-workflow-test
 LABEL org.opencontainers.image.licenses=GPL-2.0-only
 
 RUN pacman -Syu --noconfirm

--- a/main.go
+++ b/main.go
@@ -105,4 +105,5 @@ func main() {
 	}
 
 	// Just a test comment
+	// Another test comment
 }

--- a/main.go
+++ b/main.go
@@ -103,7 +103,4 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-
-	// Just a test comment
-	// Another test comment
 }

--- a/main.go
+++ b/main.go
@@ -103,4 +103,6 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
+
+	// Just a test comment
 }


### PR DESCRIPTION
One workflow with three jobs will be in place: 

- A changeset job that gathers the list of changes in the commit.
- A PR job: this will get triggered when someone opens a PR. Images will be built and added as job artifacts (so they don't stick around forever and consume metered space in GHCR). 
- A `main` branch job: this will get triggered when commits are pushed to `main` (either from a push, or a PR is merged). Images will be built and pushed to GHCR. 

Both jobs utilize Docker build caching through the use of the `cache-from` and `cache-to` fields in the Docker build steps. 

The jobs execute conditionally. The first main condition (as noted in the bullets above) is the event type that triggered the action. The next condition (or group of conditions really) tests whether or not to run the job based on the changeset in the commit. Unless the specified files are modified, the jobs will not run. 

The specified files for the control plane are:
- `Dockerfile`
- `go.mod`
- `go.sum`
- `main.go`
- `controllers/*`
- `LICENSE`

The specified files for the data plane are:
- `dataplane/Dockerfile`
- `dataplane/go.mod`
- `dataplane/go.sum`
- `dataplane/main.go`
- `dataplane/xdp.c`
- `dataplane/Makefile`
- `dataplane/LICENCE`

Let me know if these aren't correct. 

I tested out the `main` branch workflow in a clone of the repository [here](https://github.com/Kong/blixt-workflow-test/actions/runs/3285628261/jobs/5412911877).