### PR TITLE
chore: add template for udproute controller

### DIFF
--- a/dataplane/Cargo.toml
+++ b/dataplane/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["loader", "common", "xtask"]
+members = ["controllers/udproute", "loader", "common", "xtask"]

--- a/dataplane/controllers/udproute/Cargo.toml
+++ b/dataplane/controllers/udproute/Cargo.toml
@@ -1,0 +1,52 @@
+[package]
+name = "udproute-controller"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[features]
+default = ["openssl-tls", "kubederive", "ws", "latest", "runtime"]
+kubederive = ["kube/derive"]
+openssl-tls = ["kube/client", "kube/openssl-tls"]
+rustls-tls = ["kube/client", "kube/rustls-tls"]
+runtime = ["kube/runtime"]
+ws = ["kube/ws"]
+latest = ["k8s-openapi/v1_25"]
+
+[dependencies]
+tokio-util = "0.7.0"
+assert-json-diff = "2.0.1"
+validator = { version = "0.16.0", features = ["derive"] }
+anyhow = "1.0.44"
+futures = "0.3.17"
+jsonpath_lib = "0.3.0"
+kube = { version = "^0.76.0", default-features = false, features = ["admission"] }
+kube-derive = { version = "^0.76.0", default-features = false } # only needed to opt out of schema
+k8s-openapi = { version = "0.16.0", default-features = false }
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.68"
+serde_yaml = "0.8.21"
+tokio = { version = "1.14.0", features = ["full"] }
+either = "1.6.1"
+schemars = "0.8.6"
+static_assertions = "1.1.0"
+tar = "0.4.37"
+tracing = "0.1.36"
+tracing-subscriber = "0.3.3"
+warp = { version = "0.3", default-features = false, features = ["tls"] }
+http = "0.2.5"
+json-patch = "0.2.6"
+tower = { version = "0.4.6", features = ["limit"] }
+tower-http = { version = "0.3.2", features = ["trace", "decompression-gzip"] }
+hyper = { version = "0.14.13", features = ["client", "http1", "stream", "tcp"] }
+thiserror = "1.0.29"
+backoff = "0.4.0"
+clap = { version = "4.0", default-features = false, features = ["std", "cargo", "derive"] }
+edit = "0.1.3"
+tokio-stream = { version = "0.1.9", features = ["net"] }
+gateway-api = "0.1.0"
+
+# TODO lib
+[[bin]]
+name = "udproute-controller"
+path = "src/main.rs"

--- a/dataplane/controllers/udproute/src/main.rs
+++ b/dataplane/controllers/udproute/src/main.rs
@@ -1,0 +1,68 @@
+#![allow(clippy::unnecessary_lazy_evaluations)]
+
+use anyhow::Result;
+use futures::StreamExt;
+use gateway_api::apis::experimental::udproutes::UDPRoute;
+use k8s_openapi::api::core::v1::ConfigMap;
+use kube::{
+    api::{Api, ListParams, ObjectMeta, Patch, PatchParams, Resource},
+    runtime::controller::{Action, Controller},
+    Client, CustomResource, ResourceExt,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, io::BufRead, sync::Arc};
+use thiserror::Error;
+use tokio::time::Duration;
+use tracing::*;
+
+#[derive(Debug, Error)]
+enum Error {
+    #[error("Failed to create ConfigMap: {0}")]
+    ConfigMapCreationFailed(#[source] kube::Error),
+    #[error("MissingObjectKey: {0}")]
+    MissingObjectKey(&'static str),
+}
+
+async fn reconcile(route: Arc<UDPRoute>, ctx: Arc<Data>) -> Result<Action, Error> {
+    // let client = &ctx.client;
+    let route_namespace = route.namespace().unwrap();
+    let route_name = route.name_any();
+
+    info!("found UDPRoute {}/{}", route_namespace, route_name);
+
+    // TODO: build routing info and push to eBPF maps
+
+    Ok(Action::requeue(Duration::from_secs(300)))
+}
+
+fn error_policy(_object: Arc<UDPRoute>, _error: &Error, _ctx: Arc<Data>) -> Action {
+    Action::requeue(Duration::from_secs(1))
+}
+
+struct Data {
+    client: Client,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    let client = Client::try_default().await?;
+
+    let udproutes = Api::<UDPRoute>::all(client.clone());
+
+    info!("starting UDPRoute controller");
+
+    Controller::new(udproutes, ListParams::default())
+        .shutdown_on_signal()
+        .run(reconcile, error_policy, Arc::new(Data { client }))
+        .for_each(|res| async move {
+            match res {
+                Ok(o) => info!("reconciled {:?}", o),
+                Err(e) => warn!("reconcile failed: {}", e),
+            }
+        })
+        .await;
+    info!("controller terminated");
+    Ok(())
+}


### PR DESCRIPTION
This patch simply adds the skeleton for a `UDPRoute` controller.