### PR TITLE
add ci linting and tests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,38 @@
+name: lint
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - 'main'
+    tags:
+      - '*'
+  workflow_dispatch: {}
+
+jobs:
+  golangci-lint:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Setup go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '^1.19'
+
+    - name: Cache Go modules
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-build-codegen-
+
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Run Linters
+      uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,38 @@
+name: tests
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - 'main'
+    tags:
+      - '*'
+  workflow_dispatch: {}
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: setup golang
+      uses: actions/setup-go@v3
+      with:
+        go-version: '^1.19'
+
+    - name: cache go modules
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-build-codegen-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-build-codegen-
+
+    - name: checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: run unit tests
+      run: go test -race -v ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN go mod download
 # Copy the go source
 COPY main.go main.go
 COPY controllers/ controllers/
+COPY pkg/ pkg/
+COPY internal/ internal/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go

--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -90,7 +90,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	if gwc.Spec.ControllerName != GatewayClassControllerName {
+	if gwc.Spec.ControllerName != vars.GatewayClassControllerName {
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/gateway_controller_test.go
+++ b/controllers/gateway_controller_test.go
@@ -1,0 +1,92 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kong/blixt/internal/test/utils"
+)
+
+func TestGatewayReconciler_gatewayHasMatchingGatewayClass(t *testing.T) {
+	logger, output := utils.NewBytesBufferLogger()
+	managedGWC, unmanagedGWC, fakeClient := utils.NewFakeClientWithGatewayClasses()
+	r := GatewayReconciler{
+		Client: fakeClient,
+		Scheme: fakeClient.Scheme(),
+		Log:    logger,
+	}
+
+	for _, tt := range []struct {
+		name             string
+		obj              client.Object
+		expected         bool
+		logEntryExpected string
+	}{
+		{
+			name: "a gateway with a gatewayclass managed by our controller name matches",
+			obj: &gatewayv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "managed-gateway",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: gatewayv1beta1.GatewaySpec{
+					GatewayClassName: managedGWC,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "a gateway with a gatewayclass NOT managed by our controller name doesn't match",
+			obj: &gatewayv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unmanaged-gateway",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: gatewayv1beta1.GatewaySpec{
+					GatewayClassName: unmanagedGWC,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "a gateway with a gatewayclass which is missing doesn't match",
+			obj: &gatewayv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "unmanaged-gateway",
+					Namespace: corev1.NamespaceDefault,
+				},
+				Spec: gatewayv1beta1.GatewaySpec{
+					GatewayClassName: "non-existent-gateway-class",
+				},
+			},
+			expected:         false,
+			logEntryExpected: "gatewayclass not found",
+		},
+		{
+			name:             "if inexplicably controller-runtime feeds the predicate a non-gateway object, it doesn't match",
+			obj:              &gatewayv1beta1.HTTPRoute{},
+			expected:         false,
+			logEntryExpected: "unexpected object type in gateway watch predicates",
+		},
+	} {
+		obj := tt.obj
+		expected := tt.expected
+		logEntry := tt.logEntryExpected
+
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, expected, r.gatewayHasMatchingGatewayClass(obj))
+			if logEntry == "" {
+				assert.Equal(t, logEntry, output.String())
+			} else {
+				assert.Contains(t, output.String(), logEntry)
+			}
+		})
+
+		output.Reset()
+	}
+}

--- a/controllers/gatewayclass_controller.go
+++ b/controllers/gatewayclass_controller.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 
+	"github.com/kong/blixt/pkg/vars"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -16,8 +17,6 @@ import (
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=gatewayclasses/finalizers,verbs=update
-
-const GatewayClassControllerName = "konghq.com/blixt"
 
 // GatewayClassReconciler reconciles a GatewayClass object
 type GatewayClassReconciler struct {
@@ -33,7 +32,7 @@ func (r *GatewayClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			if !ok {
 				return false
 			}
-			return gwc.Spec.ControllerName == GatewayClassControllerName // filter out unmanaged GWCs
+			return gwc.Spec.ControllerName == vars.GatewayClassControllerName // filter out unmanaged GWCs
 		})).
 		Complete(r)
 }
@@ -50,7 +49,7 @@ func (r *GatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	if gwc.Spec.ControllerName != GatewayClassControllerName {
+	if gwc.Spec.ControllerName != vars.GatewayClassControllerName {
 		return ctrl.Result{}, nil
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/kong/blixt
 go 1.19
 
 require (
+	github.com/go-logr/logr v1.2.3
 	github.com/kong/kubernetes-testing-framework v0.22.3
+	github.com/stretchr/testify v1.8.0
 	k8s.io/api v0.25.2
 	k8s.io/apimachinery v0.25.2
 	k8s.io/client-go v0.25.2
@@ -37,7 +39,7 @@ require (
 	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
@@ -63,6 +65,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-logr/zapr v1.2.3 h1:a9vnzlIBPQBBkeaR9IuMUfmVOrQlkoC4YfPoFkX3T7A=
 github.com/go-logr/zapr v1.2.3/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
@@ -361,14 +363,17 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
+github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/xlab/treeprint v1.1.0 h1:G/1DjNkPpfZCFt9CSh6b5/nY4VimlbHF3Rh4obvtzDk=
 github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/test/utils/utils.go
+++ b/internal/test/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-logr/stdr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -47,7 +48,7 @@ func NewFakeClientWithGatewayClasses(initObjects ...client.Object) (gatewayv1bet
 	}
 
 	scheme := runtime.NewScheme()
-	gatewayv1beta1.AddToScheme(scheme)
+	utilruntime.Must(gatewayv1beta1.AddToScheme(scheme))
 
 	fakeClient := fake.NewClientBuilder().WithObjects(
 		managedGatewayClass,

--- a/internal/test/utils/utils.go
+++ b/internal/test/utils/utils.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+	"bytes"
+	"log"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/stdr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	"github.com/kong/blixt/pkg/vars"
+)
+
+// NewBytesBufferLogger creates a standard logger with a *bytes.Buffer as the
+// output wrapped in a logr.Logger implementation to provide to reconcilers.
+func NewBytesBufferLogger() (logr.Logger, *bytes.Buffer) {
+	output := new(bytes.Buffer)
+	stdr.SetVerbosity(1)
+	return stdr.NewWithOptions(log.New(output, "", log.Default().Flags()), stdr.Options{}), output
+}
+
+// NewFakeClientWithGatewayClasses creates a new fake controller-runtime
+// client.Client for testing, with two GatewayClasses pre-loaded into the
+// client: one that's managed by our GatewayClassControllerName, and one that
+// isn't. You can also optionally provide more init objects to pre-load if
+// needed.
+func NewFakeClientWithGatewayClasses(initObjects ...client.Object) (gatewayv1beta1.ObjectName, gatewayv1beta1.ObjectName, client.Client) {
+	managedGatewayClass := &gatewayv1beta1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "managed-gateway-class",
+		},
+		Spec: gatewayv1beta1.GatewayClassSpec{
+			ControllerName: vars.GatewayClassControllerName,
+		},
+	}
+	unmanagedGatewayClass := &gatewayv1beta1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "unmanaged-gateway-class",
+		},
+		Spec: gatewayv1beta1.GatewayClassSpec{
+			ControllerName: "kubernetes.io/unmanaged",
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	gatewayv1beta1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithObjects(
+		managedGatewayClass,
+		unmanagedGatewayClass,
+	).
+		WithObjects(initObjects...).
+		WithScheme(scheme).
+		Build()
+
+	return gatewayv1beta1.ObjectName(managedGatewayClass.Name),
+		gatewayv1beta1.ObjectName(unmanagedGatewayClass.Name),
+		fakeClient
+}

--- a/pkg/vars/vars.go
+++ b/pkg/vars/vars.go
@@ -1,0 +1,5 @@
+package vars
+
+// GatewayClassControllerName is the unique identifier indicating controller
+// responsible for relevant resources.
+const GatewayClassControllerName = "konghq.com/blixt"

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -38,7 +38,7 @@ func TestMain(m *testing.M) {
 
 func exitOnErr(err error) {
 	if err != nil {
-		fmt.Fprintf(os.Stderr, err.Error())
+		fmt.Fprint(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This PR includes a fix for our `GatewayClass` watch predicate, adds some testing utilities for unit testing reconcilers and adds unit tests for the Gateway controllers `gatewayHasMatchingGatewayClass` watch predicate.

Additionally this adds CI workflows for automatically running lint and unit tests on every PR.

Resolves #17 