### PR TITLE
Increase golangci-lint timeout

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -36,3 +36,5 @@ jobs:
 
     - name: Run Linters
       uses: golangci/golangci-lint-action@v3
+      with:
+        args: --timeout 3m --verbose


### PR DESCRIPTION
Fix `golangci-lint` timeout via GitHub Actions workflow.

The default timeout is at 1 minute. Increasing the timeout should keep the workflow going until completed. May need to adjust as the code base gets larger.

Fixes https://github.com/Kong/blixt/issues/27

Signed-off-by: Antonette Caldwell <pullmana8@gmail.com>