### PR TITLE
fix: add protoc to rust build

### DIFF
--- a/dataplane/Dockerfile
+++ b/dataplane/Dockerfile
@@ -1,5 +1,8 @@
 FROM rust as builder
 
+RUN apt-get update
+RUN apt-get install protobuf-compiler -qq
+
 WORKDIR /workspace
 
 COPY . .


### PR DESCRIPTION
Adds `protoc` to the build phase for building the dataplane image as needed for the new Rust based dataplane.