### PR TITLE
chore: various cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,10 @@
 # More info: https://docs.docker.com/engine/reference/builder/#dockerignore-file
 # Ignore build and test binaries.
+.github/
 bin/
 testbin/
 dataplane/
+tools/
+bin/
+config/
+*.md

--- a/Makefile
+++ b/Makefile
@@ -263,6 +263,8 @@ catalog-build: opm ## Build a catalog image.
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
+KIND_CLUSTER ?= blixt-dev
+
 .PHONY: build.cluster
 build.cluster: $(KTF) # builds a KIND cluster which can be used for testing and development
-	PATH="$(LOCALBIN):${PATH}" $(KTF) env create --name blixt-development --addon metallb
+	PATH="$(LOCALBIN):${PATH}" $(KTF) env create --name $(KIND_CLUSTER) --addon metallb

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ After these goals are achieved, further goals will be decided.
 ## Usage
 
 > **Note**: Currently usage is only possible on [Kubernetes In Docker
-> (KIND)][kind] clusters.
+> (KIND)][kind] clusters. You can generate a new development cluster for
+> testing with `make build.cluster`.
 
 Deploy [Gateway API][gwapi] [CRDs][crds]:
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ After these goals are achieved, further goals will be decided.
 
 ## Usage
 
+> **Note**: Currently usage is only possible on [Kubernetes In Docker
+> (KIND)][kind] clusters.
+
 Deploy [Gateway API][gwapi] [CRDs][crds]:
 
 ```console
-kubectl kustomize https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental | kubectl apply -f -
+kubectl kustomize https://github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.1 | kubectl apply -f -
 ```
 
 Deploy:
@@ -67,6 +70,20 @@ Deploy:
 kubectl kustomize config/default | kubectl apply -f -
 ```
 
+At this point you should see the `controlplane` and `dataplane` pods running
+in the `blixt-system` namespace:
+
+```console
+$ kubectl -n blixt-system get pods
+NAME                                 READY   STATUS    RESTARTS   AGE
+blixt-controlplane-cdccc685b-9dxj2   2/2     Running   0          83s
+blixt-dataplane-brsl9                1/1     Running   0          83s
+```
+
+Check the `config/samples` directory for `Gateway` and `*Route` examples you
+can now deploy.
+
+[kind]:https://github.com/kubernetes-sigs/kind
 [gwapi]:https://github.com/kubernetes-sigs/gateway-api
 [crds]:https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -27,7 +27,7 @@ bases:
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
-# If you want your controller-manager to expose the /metrics
+# If you want your controlplane to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controlplane
   namespace: system
 spec:
   template:

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controlplane
   namespace: system
 spec:
   template:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -2,27 +2,27 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-    control-plane: controller-manager
+    control-plane: controlplane
   name: system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: controlplane
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: controlplane
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: controlplane
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        control-plane: controlplane
     spec:
       securityContext:
         runAsNonRoot: true
@@ -67,5 +67,5 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-      serviceAccountName: controller-manager
+      serviceAccountName: controlplane
       terminationGracePeriodSeconds: 10

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 #    group: apps
 #    version: v1
 #    kind: Deployment
-#    name: controller-manager
+#    name: controlplane
 #    namespace: system
 #  patch: |-
 #    # Remove the manager container's "cert" volumeMount, since OLM will create and mount a set of certs.

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,8 +4,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
-  name: controller-manager-metrics-monitor
+    control-plane: controlplane
+  name: controlplane-metrics-monitor
   namespace: system
 spec:
   endpoints:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: controlplane

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: controlplane
   namespace: system

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
-  name: controller-manager-metrics-service
+    control-plane: controlplane
+  name: controlplane-metrics-service
   namespace: system
 spec:
   ports:
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: controlplane

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: controlplane
   namespace: system

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: controlplane
   namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: controller-manager
+  name: controlplane
   namespace: system

--- a/dataplane/.dockerignore
+++ b/dataplane/.dockerignore
@@ -1,1 +1,3 @@
+.vim/
 target/
+*.md

--- a/dataplane/Dockerfile
+++ b/dataplane/Dockerfile
@@ -7,14 +7,20 @@ RUN rustup default stable
 RUN rustup install nightly
 RUN rustup component add rust-src --toolchain nightly
 RUN rustup target add x86_64-unknown-linux-musl
-RUN cargo install bpf-linker
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    cargo install bpf-linker
 
 WORKDIR /workspace
 
 COPY . .
-RUN --mount=type=cache,target=/workspace/target/ cargo xtask build-ebpf --release
-RUN --mount=type=cache,target=/workspace/target/ RUSTFLAGS=-Ctarget-feature=+crt-static cargo build --release --target=x86_64-unknown-linux-musl
-RUN --mount=type=cache,target=/workspace/target/ cp /workspace/target/x86_64-unknown-linux-musl/release/loader /workspace/dataplane
+RUN --mount=type=cache,target=/workspace/target/ \
+    --mount=type=cache,target=/root/.cargo/registry \
+    cargo xtask build-ebpf --release
+RUN --mount=type=cache,target=/workspace/target/ \
+    --mount=type=cache,target=/root/.cargo/registry \
+    RUSTFLAGS=-Ctarget-feature=+crt-static cargo build --release --target=x86_64-unknown-linux-musl
+RUN --mount=type=cache,target=/workspace/target/ \
+    cp /workspace/target/x86_64-unknown-linux-musl/release/loader /workspace/dataplane
 
 FROM alpine
 

--- a/dataplane/Makefile
+++ b/dataplane/Makefile
@@ -1,5 +1,6 @@
 IMAGE ?= ghcr.io/kong/blixt-dataplane
 TAG ?= latest
+KIND_CLUSTER ?= blixt-dev
 
 all: build
 
@@ -20,3 +21,8 @@ build.release:
 .PHONY: build.image
 build.image:
 	DOCKER_BUILDKIT=1 docker build -t $(IMAGE):$(TAG) ./
+
+.PHONY: load.image
+load.image: build.image
+	kind load docker-image $(IMAGE):$(TAG) --name $(KIND_CLUSTER) && \
+		kubectl -n blixt-system rollout restart daemonset blixt-dataplane

--- a/pkg/vars/vars.go
+++ b/pkg/vars/vars.go
@@ -17,7 +17,7 @@ const (
 const (
 	// DefaultControlPlaneDeploymentName is the name that will be used for the
 	// controlplane's Deployment (by default).
-	DefaultControlPlaneDeploymentName = "blixt-controller-manager"
+	DefaultControlPlaneDeploymentName = "blixt-controlplane"
 
 	// DefaultDataPlaneDaemonSetName is the name that will be used for the
 	// dataplane's DaemonSet (by default).

--- a/tools/udp-test-server/.dockerignore
+++ b/tools/udp-test-server/.dockerignore
@@ -1,1 +1,2 @@
 target/
+*.md

--- a/tools/udp-test-server/Dockerfile
+++ b/tools/udp-test-server/Dockerfile
@@ -1,7 +1,6 @@
 FROM rust as builder
 
 RUN apt-get update
-
 RUN apt-get install musl-tools -yq
 
 RUN rustup target add x86_64-unknown-linux-musl
@@ -9,12 +8,15 @@ RUN rustup target add x86_64-unknown-linux-musl
 WORKDIR /workspace
 
 COPY Cargo.toml Cargo.toml
-
 COPY Cargo.lock Cargo.lock
-
 COPY src/main.rs src/main.rs
 
-RUN RUSTFLAGS=-Ctarget-feature=+crt-static cargo build --release --target=x86_64-unknown-linux-musl
+RUN --mount=type=cache,target=/workspace/target/ \
+    --mount=type=cache,target=/usr/local/cargo/registry/ \
+    RUSTFLAGS=-Ctarget-feature=+crt-static cargo build --release --target=x86_64-unknown-linux-musl
+
+RUN --mount=type=cache,target=/workspace/target/ \
+    cp /workspace/target/x86_64-unknown-linux-musl/release/udp-test-server /workspace/udp-test-server
 
 FROM gcr.io/distroless/static
 
@@ -22,6 +24,6 @@ LABEL org.opencontainers.image.source https://github.com/kong/blixt-udp-test-ser
 
 WORKDIR /
 
-COPY --from=builder /workspace/target/x86_64-unknown-linux-musl/release/udp-test-server /udp-test-server
+COPY --from=builder /workspace/udp-test-server /udp-test-server
 
 ENTRYPOINT ["/udp-test-server"]

--- a/tools/udp-test-server/src/main.rs
+++ b/tools/udp-test-server/src/main.rs
@@ -58,8 +58,6 @@ async fn run_health_server(port: u16, mut rx: Receiver<u16>) -> std::io::Result<
 
     loop {
         let (mut stream, _) = listener.accept().await?;
-        let mut buf = [0; 1024];
-        stream.read(&mut buf).await?;
         stream.write_all("ready".as_bytes()).await?;
         let peer = stream.peer_addr()?;
         println!("received health check from {}", peer);


### PR DESCRIPTION
- chore: rename controller-manager to controlplane
- chore: cleanup the README.md
- chore: improve .dockerignore files throughout
- fix: udp test server ignore stream data
- fix: reduce spam from healthcheck peers
- chore: improve caching for rust image builds
- feat: add makefile directive to build dev cluster