### PR TITLE
chore: experimental proto3 flag

### DIFF
--- a/dataplane/api-server/build.rs
+++ b/dataplane/api-server/build.rs
@@ -4,6 +4,7 @@ fn main() {
     println!("building proto {}", proto_file);
 
     tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
         .build_server(true)
         .out_dir("./src")
         .compile(&[proto_file], &["."])

--- a/dataplane/xtask/build.rs
+++ b/dataplane/xtask/build.rs
@@ -1,4 +1,9 @@
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("../api-server/proto/backends.proto")?;
-    Ok(())
+fn main() {
+    let proto_file = "../api-server/proto/backends.proto";
+
+    tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .protoc_arg("--proto_path=..")
+        .compile(&[proto_file], &["."])
+        .unwrap_or_else(|e| panic!("protobuf compile error: {}", e));
 }


### PR DESCRIPTION
With Ubuntu 22.04, the latest version (installed via apt-get) of protobuf is `3.12.4`. With such a version, the dataplane build requires the flag `--experimental_allow_proto3_optional` to be successful. This PR introduces such a flag in both the api-server and xtask build targets.