### PR TITLE
chore: clippy derive_partial_eq_without_eq enabled

### DIFF
--- a/dataplane/api-server/src/backends.rs
+++ b/dataplane/api-server/src/backends.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Vip {
     #[prost(uint32, tag = "1")]
@@ -5,6 +6,7 @@ pub struct Vip {
     #[prost(uint32, tag = "2")]
     pub port: u32,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Target {
     #[prost(uint32, tag = "1")]
@@ -14,6 +16,7 @@ pub struct Target {
     #[prost(uint32, optional, tag = "3")]
     pub ifindex: ::core::option::Option<u32>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Targets {
     #[prost(message, optional, tag = "1")]
@@ -21,16 +24,19 @@ pub struct Targets {
     #[prost(message, optional, tag = "2")]
     pub target: ::core::option::Option<Target>,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Confirmation {
     #[prost(string, tag = "1")]
     pub confirmation: ::prost::alloc::string::String,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PodIp {
     #[prost(uint32, tag = "1")]
     pub ip: u32,
 }
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InterfaceIndexConfirmation {
     #[prost(uint32, tag = "1")]
@@ -164,7 +170,7 @@ pub mod backends_client {
 pub mod backends_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    ///Generated trait containing gRPC methods that should be implemented for use with BackendsServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with BackendsServer.
     #[async_trait]
     pub trait Backends: Send + Sync + 'static {
         async fn get_interface_index(


### PR DESCRIPTION
With Rust 1.66 (https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-166), `derive_partial_eq_without_eq` has been moved to nursery, meaning that it is enabled by default (https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#moves-and-deprecations). 