### PR TITLE
fix: pin Rust nightly version to 2023-01-10

### DIFF
--- a/dataplane/Dockerfile
+++ b/dataplane/Dockerfile
@@ -4,8 +4,8 @@ RUN pacman -Syu --noconfirm
 RUN pacman -S base-devel protobuf rustup --noconfirm
 
 RUN rustup default stable
-RUN rustup install nightly
-RUN rustup component add rust-src --toolchain nightly
+RUN rustup install nightly-2023-01-10
+RUN rustup component add rust-src --toolchain nightly-2023-01-10
 RUN rustup target add x86_64-unknown-linux-musl
 RUN --mount=type=cache,target=/root/.cargo/registry \
     cargo install bpf-linker

--- a/dataplane/ebpf/rust-toolchain.toml
+++ b/dataplane/ebpf/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel="nightly"
+#TODO: revert once this issue with aya and rust nightly is fixed: https://github.com/aya-rs/aya/issues/490
+channel="nightly-2023-01-10"

--- a/dataplane/xtask/src/build_ebpf.rs
+++ b/dataplane/xtask/src/build_ebpf.rs
@@ -42,7 +42,7 @@ pub fn build_ebpf(opts: Options) -> Result<(), anyhow::Error> {
     let dir = PathBuf::from("ebpf");
     let target = format!("--target={}", opts.target);
     let mut args = vec![
-        "+nightly",
+        "+nightly-2023-01-10",
         "build",
         "--verbose",
         target.as_str(),


### PR DESCRIPTION
The 2023-01-11 nightly rust build [broke aya](https://github.com/aya-rs/aya/issues/490) and subsequently the build of the Blixt Dataplane.
Pinning the rust toolchain version to 2023-01-10 as a temporary fix.