### PR TITLE
feat: readiness and liveliness probe created

### DIFF
--- a/config/dataplane/dataplane.yaml
+++ b/config/dataplane/dataplane.yaml
@@ -28,3 +28,9 @@ spec:
         - name: RUST_LOG
           value: debug
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          grpc:
+            port: 9874
+        readinessProbe:
+          grpc:
+            port: 9874


### PR DESCRIPTION
Should provide a preliminary readiness and liveness probe. Other options were considered, but this seemed the less intrusive and most expedient at the moment.

resolves #51 